### PR TITLE
Add context menu and file reordering features

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -704,6 +704,12 @@ body {
     color: white;
 }
 
+.menu-action-delete:hover,
+.menu-action-delete:active {
+    background: var(--danger-color);
+    color: white;
+}
+
 .highlight-menu-btn {
     display: flex;
     align-items: center;
@@ -1470,6 +1476,25 @@ body {
     transition: max-height 0.5s ease-in;
 }
 
+/* File drag styles */
+.accordion-item.dragging {
+    opacity: 0.6;
+    cursor: grabbing;
+}
+
+.file-drag-placeholder {
+    background: var(--primary-color);
+    opacity: 0.2;
+    border: 2px dashed var(--primary-color);
+    border-radius: var(--radius-sm);
+    margin: 4px 0;
+}
+
+.accordion-header.long-press {
+    background: var(--bg-color);
+    box-shadow: var(--shadow);
+}
+
 .accordion-actions {
     display: flex;
     gap: 4px;
@@ -1875,14 +1900,6 @@ body {
 .ProseMirror [data-list-kind="task"][data-checked="true"] {
     opacity: 0.6;
     text-decoration: line-through;
-}
-
-/* Bullet list */
-.ProseMirror [data-list-kind="bullet"]::before {
-    content: '⦿';
-    font-size: 14px;
-    line-height: 1.6;
-    color: var(--text-light);
 }
 
 /* Ordered list */

--- a/docs/js/FileExplorer.js
+++ b/docs/js/FileExplorer.js
@@ -204,13 +204,19 @@ class FileExplorer {
     /**
      * Create new file
      * @param {string} directory - Directory path
-     * @param {string} fileName - File name (without .md)
+     * @param {string} fileName - File name (without extension)
      * @param {string} viewName - View name for reload
      */
     static async createNewFile(directory, fileName, viewName) {
         const api = new GitHubAPI(AppState.token, AppState.repo);
-        const filePath = `${directory}/${fileName}.md`;
-        const content = `# ${fileName}\n\n- First item\n`;
+        const filePath = `json/${directory}/${fileName}.json`;
+
+        // Create empty ProseMirror document
+        const emptyDoc = {
+            type: 'doc',
+            content: []
+        };
+        const content = JSON.stringify(emptyDoc, null, 2);
 
         try {
             if (AppState.isOnline) {

--- a/docs/js/GitHubAPI.js
+++ b/docs/js/GitHubAPI.js
@@ -54,6 +54,17 @@ class GitHubAPI {
         });
     }
 
+    async deleteFile(path, message) {
+        // Get current file to get SHA
+        const current = await this.request(`/contents/${path}`);
+        const sha = current.sha;
+
+        return this.request(`/contents/${path}`, 'DELETE', {
+            message,
+            sha
+        });
+    }
+
     async createIssue(title, body) {
         return this.request('/issues', 'POST', {
             title,

--- a/docs/js/HighlightMenu.js
+++ b/docs/js/HighlightMenu.js
@@ -25,11 +25,16 @@ class HighlightMenu {
             const viewName = menu.dataset.view;
             const fileIndex = parseInt(menu.dataset.fileIndex, 10);
             const itemIndex = parseInt(menu.dataset.itemIndex, 10);
+            const isFileLevel = itemIndex === -1;
 
             // Handle color buttons
             if (button.dataset.color) {
                 const color = button.dataset.color;
-                ItemActions.applyHighlight(viewName, fileIndex, itemIndex, color);
+                if (isFileLevel) {
+                    ItemActions.applyFileHighlight(viewName, fileIndex, color);
+                } else {
+                    ItemActions.applyHighlight(viewName, fileIndex, itemIndex, color);
+                }
                 this.hideHighlightMenu();
             }
             // Handle action buttons
@@ -37,12 +42,26 @@ class HighlightMenu {
                 const action = button.dataset.action;
                 this.hideHighlightMenu();
 
-                if (action === 'done') {
-                    ItemActions.completeItem(viewName, fileIndex, itemIndex);
-                } else if (action === 'indent') {
-                    ItemActions.indentItem(viewName, fileIndex, itemIndex);
-                } else if (action === 'outdent') {
-                    ItemActions.outdentItem(viewName, fileIndex, itemIndex);
+                if (isFileLevel) {
+                    // File-level actions
+                    if (action === 'toggle-file') {
+                        ItemActions.toggleFileExpanded(viewName, fileIndex);
+                    } else if (action === 'delete-file') {
+                        ItemActions.deleteFile(viewName, fileIndex);
+                    }
+                } else {
+                    // Item-level actions
+                    if (action === 'done') {
+                        ItemActions.completeItem(viewName, fileIndex, itemIndex);
+                    } else if (action === 'indent') {
+                        ItemActions.indentItem(viewName, fileIndex, itemIndex);
+                    } else if (action === 'outdent') {
+                        ItemActions.outdentItem(viewName, fileIndex, itemIndex);
+                    } else if (action === 'toggle') {
+                        ItemActions.toggleItem(viewName, fileIndex, itemIndex);
+                    } else if (action === 'delete') {
+                        ItemActions.deleteItem(viewName, fileIndex, itemIndex);
+                    }
                 }
             }
         });
@@ -99,6 +118,8 @@ class HighlightMenu {
         html += '<button type="button" class="menu-action-btn" data-action="done">Done</button>';
         html += '<button type="button" class="menu-action-btn" data-action="indent">Indent</button>';
         html += '<button type="button" class="menu-action-btn" data-action="outdent">Outdent</button>';
+        html += '<button type="button" class="menu-action-btn" data-action="toggle">Toggle</button>';
+        html += '<button type="button" class="menu-action-btn menu-action-delete" data-action="delete">Delete</button>';
 
         menu.innerHTML = html;
 
@@ -107,6 +128,56 @@ class HighlightMenu {
         menu.dataset.itemIndex = String(itemIndex);
 
         const rect = itemEl.getBoundingClientRect();
+        const top = rect.bottom + window.scrollY + 6;
+        const left = rect.left + window.scrollX;
+        menu.style.top = `${top}px`;
+        menu.style.left = `${left}px`;
+        menu.classList.remove('hidden');
+        this.highlightMenuJustOpened = true;
+        window.setTimeout(() => {
+            this.highlightMenuJustOpened = false;
+        }, 0);
+    }
+
+    /**
+     * Show highlight menu for file header
+     * @param {HTMLElement} headerEl - Header element
+     * @param {string} viewName - View name
+     * @param {number} fileIndex - File index
+     */
+    static showHighlightMenuForFile(headerEl, viewName, fileIndex) {
+        const menu = this.ensureHighlightMenu();
+        const data = AppState.data[viewName];
+        const file = data?.files?.[fileIndex];
+        const current = file?.highlight || 'none';
+        const colors = [
+            { id: 'yellow', label: 'Yellow' },
+            { id: 'green', label: 'Green' },
+            { id: 'blue', label: 'Blue' },
+            { id: 'pink', label: 'Pink' },
+            { id: 'none', label: 'Clear' }
+        ];
+
+        // Build HTML with color squares in a row, then Toggle/Delete buttons
+        let html = '<div class="color-row">';
+        colors.forEach(color => {
+            const activeClass = color.id === current ? ' active' : '';
+            html += `<button type="button" class="color-square${activeClass}" data-color="${color.id}" title="${color.label}">
+                <span class="highlight-swatch highlight-${color.id}"></span>
+            </button>`;
+        });
+        html += '</div>';
+
+        html += '<button type="button" class="menu-action-btn" data-action="toggle-file">Toggle</button>';
+        html += '<button type="button" class="menu-action-btn menu-action-delete" data-action="delete-file">Delete</button>';
+
+        menu.innerHTML = html;
+
+        menu.dataset.view = viewName;
+        menu.dataset.fileIndex = String(fileIndex);
+        menu.dataset.itemIndex = '-1'; // -1 indicates file-level menu
+
+        const rect = headerEl.getBoundingClientRect();
         const top = rect.bottom + window.scrollY + 6;
         const left = rect.left + window.scrollX;
         menu.style.top = `${top}px`;

--- a/docs/js/ViewRenderer.js
+++ b/docs/js/ViewRenderer.js
@@ -24,12 +24,13 @@ class ViewRenderer {
 
         data.files.forEach((file, fileIndex) => {
             const expandedClass = file.expanded ? 'expanded' : '';
+            const highlightClass = file.highlight ? `highlight-${file.highlight}` : '';
 
             // Count unchecked tasks from ProseMirror document
             const itemCount = this.countUncheckedTasks(file.docJSON);
 
             html += `<div class="accordion-item ${expandedClass}" data-file-index="${fileIndex}">`;
-            html += `<div class="accordion-header" onclick="ViewRenderer.toggleAccordion('${viewName}', ${fileIndex})">`;
+            html += `<div class="accordion-header ${highlightClass}" onclick="ViewRenderer.toggleAccordion('${viewName}', ${fileIndex})">`;
             html += `<span class="accordion-icon">&#9654;</span>`;
             html += `<span>${file.name}</span>`;
             html += `<span style="margin-left: auto; font-size: 0.75rem; color: var(--text-light);">(${itemCount})</span>`;
@@ -41,6 +42,9 @@ class ViewRenderer {
 
         html += '</div>';
         content.innerHTML = html;
+
+        // Bind long-press handlers to accordion headers
+        this.bindHeaderGestures(viewName);
 
         // Create ProseMirror editors for expanded accordions
         data.files.forEach((file, fileIndex) => {
@@ -113,18 +117,15 @@ class ViewRenderer {
     }
 
     /**
-     * Count unchecked tasks in ProseMirror document
+     * Count all list items in ProseMirror document
      * @param {Object} docJSON - ProseMirror document JSON
-     * @returns {number} Count of unchecked tasks
+     * @returns {number} Count of all list items
      */
     static countUncheckedTasks(docJSON) {
         let count = 0;
 
         function traverse(node) {
-            if (node.type === 'list' &&
-                node.attrs &&
-                node.attrs.kind === 'task' &&
-                node.attrs.checked === false) {
+            if (node.type === 'list') {
                 count++;
             }
             if (node.content) {
@@ -155,6 +156,244 @@ class ViewRenderer {
         if (header) {
             header.textContent = `(${itemCount})`;
         }
+    }
+
+    /**
+     * Bind long-press and drag gestures to accordion headers
+     * @param {string} viewName - The view name
+     */
+    static bindHeaderGestures(viewName) {
+        const data = AppState.data[viewName];
+        if (!data || !data.files) return;
+
+        const headers = document.querySelectorAll('.accordion-header');
+
+        headers.forEach((header, fileIndex) => {
+            let gestureState = null;
+
+            const handlePointerDown = (event) => {
+                const accordion = header.closest('.accordion-item');
+                const isExpanded = accordion.classList.contains('expanded');
+
+                // Only allow long-press when collapsed
+                if (isExpanded) return;
+
+                event.stopPropagation();
+
+                gestureState = {
+                    pointerId: event.pointerId,
+                    startX: event.clientX,
+                    startY: event.clientY,
+                    lastX: event.clientX,
+                    lastY: event.clientY,
+                    longPressTriggered: false,
+                    dragging: false,
+                    longPressTimer: null
+                };
+
+                gestureState.longPressTimer = window.setTimeout(() => {
+                    gestureState.longPressTriggered = true;
+                    header.classList.add('long-press');
+                }, 500);
+
+                if (header.setPointerCapture) {
+                    header.setPointerCapture(event.pointerId);
+                }
+            };
+
+            const handlePointerMove = (event) => {
+                if (!gestureState || gestureState.pointerId !== event.pointerId) return;
+
+                const dx = event.clientX - gestureState.startX;
+                const dy = event.clientY - gestureState.startY;
+                gestureState.lastX = event.clientX;
+                gestureState.lastY = event.clientY;
+
+                // Start dragging if long-press triggered and moved
+                if (gestureState.longPressTriggered && !gestureState.dragging && Math.abs(dy) > 10) {
+                    gestureState.dragging = true;
+                    this.startFileDrag(viewName, fileIndex, header);
+                }
+
+                if (gestureState.dragging) {
+                    this.updateFileDragPosition(viewName, event.clientY);
+                    event.preventDefault();
+                }
+            };
+
+            const handlePointerUp = (event) => {
+                if (!gestureState || gestureState.pointerId !== event.pointerId) return;
+
+                window.clearTimeout(gestureState.longPressTimer);
+
+                if (gestureState.dragging) {
+                    this.finishFileDrag(viewName);
+                } else if (gestureState.longPressTriggered) {
+                    // Show highlight menu for file
+                    HighlightMenu.showHighlightMenuForFile(header, viewName, fileIndex);
+                }
+
+                header.classList.remove('long-press');
+                gestureState = null;
+            };
+
+            const handlePointerCancel = (event) => {
+                if (!gestureState || gestureState.pointerId !== event.pointerId) return;
+                window.clearTimeout(gestureState.longPressTimer);
+                if (gestureState.dragging) {
+                    this.cleanupFileDrag(viewName);
+                }
+                header.classList.remove('long-press');
+                gestureState = null;
+            };
+
+            // Prevent default context menu on long-press
+            const handleContextMenu = (event) => {
+                const accordion = header.closest('.accordion-item');
+                const isExpanded = accordion.classList.contains('expanded');
+                if (!isExpanded) {
+                    event.preventDefault();
+                }
+            };
+
+            header.addEventListener('pointerdown', handlePointerDown);
+            header.addEventListener('pointermove', handlePointerMove);
+            header.addEventListener('pointerup', handlePointerUp);
+            header.addEventListener('pointercancel', handlePointerCancel);
+            header.addEventListener('contextmenu', handleContextMenu);
+        });
+    }
+
+    /**
+     * Start file drag
+     * @param {string} viewName - View name
+     * @param {number} fileIndex - File index
+     * @param {HTMLElement} header - Header element
+     */
+    static startFileDrag(viewName, fileIndex, header) {
+        const accordion = header.closest('.accordion-item');
+
+        if (!this.fileDragState) {
+            this.fileDragState = {};
+        }
+
+        this.fileDragState.viewName = viewName;
+        this.fileDragState.dragIndex = fileIndex;
+        this.fileDragState.currentIndex = fileIndex;
+        this.fileDragState.accordion = accordion;
+
+        // Add dragging class
+        accordion.classList.add('dragging');
+
+        // Create placeholder
+        const placeholder = document.createElement('div');
+        placeholder.className = 'file-drag-placeholder';
+        placeholder.style.height = accordion.offsetHeight + 'px';
+        this.fileDragState.placeholder = placeholder;
+
+        // Insert placeholder after accordion
+        accordion.parentNode.insertBefore(placeholder, accordion.nextSibling);
+    }
+
+    /**
+     * Update file drag position
+     * @param {string} viewName - View name
+     * @param {number} clientY - Current Y position
+     */
+    static updateFileDragPosition(viewName, clientY) {
+        if (!this.fileDragState) return;
+
+        const accordions = Array.from(document.querySelectorAll('.accordion-item'));
+        const draggedAccordion = this.fileDragState.accordion;
+
+        // Find the accordion closest to the cursor
+        let closestAccordion = null;
+        let closestDistance = Infinity;
+
+        accordions.forEach(acc => {
+            if (acc === draggedAccordion) return;
+
+            const rect = acc.getBoundingClientRect();
+            const center = rect.top + rect.height / 2;
+            const distance = Math.abs(clientY - center);
+
+            if (distance < closestDistance) {
+                closestDistance = distance;
+                closestAccordion = acc;
+            }
+        });
+
+        if (closestAccordion) {
+            const closestRect = closestAccordion.getBoundingClientRect();
+            const placeholder = this.fileDragState.placeholder;
+
+            // Insert placeholder before or after closest accordion
+            if (clientY < closestRect.top + closestRect.height / 2) {
+                closestAccordion.parentNode.insertBefore(placeholder, closestAccordion);
+            } else {
+                closestAccordion.parentNode.insertBefore(placeholder, closestAccordion.nextSibling);
+            }
+        }
+    }
+
+    /**
+     * Finish file drag
+     * @param {string} viewName - View name
+     */
+    static finishFileDrag(viewName) {
+        if (!this.fileDragState) return;
+
+        const data = AppState.data[viewName];
+        if (!data || !data.files) return;
+
+        const draggedAccordion = this.fileDragState.accordion;
+        const placeholder = this.fileDragState.placeholder;
+
+        // Calculate new index based on placeholder position
+        const accordions = Array.from(document.querySelectorAll('.accordion-item'));
+        const newIndex = Array.from(placeholder.parentNode.children).indexOf(placeholder);
+        const oldIndex = this.fileDragState.dragIndex;
+
+        // Move the dragged accordion to placeholder position
+        placeholder.parentNode.insertBefore(draggedAccordion, placeholder);
+        placeholder.remove();
+
+        // Update data order
+        const [movedFile] = data.files.splice(oldIndex, 1);
+        const adjustedNewIndex = newIndex > oldIndex ? newIndex - 1 : newIndex;
+        data.files.splice(adjustedNewIndex, 0, movedFile);
+
+        // Cleanup
+        draggedAccordion.classList.remove('dragging');
+        this.fileDragState = null;
+
+        // Re-render to update file indices
+        this.render(viewName);
+
+        if (window.UI && UI.showToast) {
+            UI.showToast('File reordered', 'success');
+        }
+    }
+
+    /**
+     * Cleanup file drag
+     * @param {string} viewName - View name
+     */
+    static cleanupFileDrag(viewName) {
+        if (!this.fileDragState) return;
+
+        const draggedAccordion = this.fileDragState.accordion;
+        const placeholder = this.fileDragState.placeholder;
+
+        if (draggedAccordion) {
+            draggedAccordion.classList.remove('dragging');
+        }
+
+        if (placeholder && placeholder.parentNode) {
+            placeholder.remove();
+        }
+
+        this.fileDragState = null;
     }
 }
 


### PR DESCRIPTION
Features implemented:
- Long-press context menu for items and files with 5-color palette
- Delete functionality for items (with children) and files (with confirmation)
- Toggle functionality for items (convert to toggle-list type using ProseMirror)
- Toggle functionality for files (expand/collapse accordion state)
- File color highlighting (stored in AppState, rendered on headers)
- File reordering via long-press drag on collapsed accordion headers
- Empty ProseMirror JSON template for new file creation
- Item count now counts ALL list nodes (not just unchecked)
- Removed custom ⦿ bullet character, using ProseMirror default

Technical changes:
- Updated HighlightMenu to support both item and file-level menus
- Added ItemActions methods: toggleItem, deleteItem, applyFileHighlight, toggleFileExpanded, deleteFile
- Enhanced ViewRenderer with gesture handling for accordion headers
- Implemented file drag-and-drop reordering in ViewRenderer
- Added GitHubAPI.deleteFile method
- Updated FileExplorer.createNewFile to use empty JSON documents
- Added CSS styles for file drag placeholder and delete button